### PR TITLE
Render nullable args for AutoDispose

### DIFF
--- a/GodotHat.SourceGenerators.Test/OnExitTreeGeneratorTest.cs
+++ b/GodotHat.SourceGenerators.Test/OnExitTreeGeneratorTest.cs
@@ -168,7 +168,7 @@ public partial class MyNode
 
     private IDisposable? __disposable_MyCall;
 
-    protected void UpdateMyCall(bool foo, string message)
+    protected void UpdateMyCall(bool foo, string? message)
     {
         DisposeMyCall();
         __disposable_MyCall = MyCall(foo, message);

--- a/GodotHat.SourceGenerators/GeneratorUtil.cs
+++ b/GodotHat.SourceGenerators/GeneratorUtil.cs
@@ -10,7 +10,7 @@ internal static class GeneratorUtil
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
             genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
             parameterOptions:
-            SymbolDisplayParameterOptions.IncludeParamsRefOut |
+            SymbolDisplayParameterOptions.IncludeModifiers |
             SymbolDisplayParameterOptions.IncludeExtensionThis |
             SymbolDisplayParameterOptions.IncludeType |
             SymbolDisplayParameterOptions.IncludeName |
@@ -18,7 +18,9 @@ internal static class GeneratorUtil
             SymbolDisplayParameterOptions.IncludeDefaultValue,
             miscellaneousOptions:
             SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers |
-            SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+            SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
+            SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
+            );
 
 
     public static IEnumerable<ITypeSymbol> GetThisAndBaseTypes(ITypeSymbol? symbol)


### PR DESCRIPTION
Fix rendering of nullable args when generating an UpdateFoo method for:
```csharp
[AutoDispose]
private IDisposable Foo(string? someArg);
```