### PR TITLE
Fix script methods with args

### DIFF
--- a/GodotHat.Attributes/GodotIgnoreAttribute.cs
+++ b/GodotHat.Attributes/GodotIgnoreAttribute.cs
@@ -1,0 +1,9 @@
+namespace GodotHat;
+
+/// <summary>
+/// Do not expose method to Godot via GodotHat's ScriptMethods generator.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public class GodotIgnoreAttribute : Attribute
+{
+}

--- a/GodotHat.SourceGenerators.Test/ScriptMethodsGeneratorTest.cs
+++ b/GodotHat.SourceGenerators.Test/ScriptMethodsGeneratorTest.cs
@@ -36,6 +36,11 @@ public partial class MyNode : Node
     public void DoThing4(string[] args)
     {{
     }}
+
+    [GodotIgnore]
+    public void DoThingIgnored()
+    {{
+    }}
 }}
 ";
 

--- a/GodotHat.SourceGenerators.Test/ScriptMethodsGeneratorTest.cs
+++ b/GodotHat.SourceGenerators.Test/ScriptMethodsGeneratorTest.cs
@@ -1,0 +1,243 @@
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit.Abstractions;
+
+namespace GodotHat.SourceGenerators.Test;
+
+public class ScriptMethodsGeneratorTest
+{
+    private readonly ITestOutputHelper testOutputHelper;
+
+    private const string MyNodeSource = $@"
+namespace Test.Node;
+
+using System;
+using alecs.Core;
+using Godot;
+using GodotHat;
+
+public partial class MyNode : Node
+{{
+    [OnReady]
+    private IDisposable DoThing()
+    {{
+        return new List<string>().Select(x => x).GetEnumerator(); 
+    }}
+
+    public void DoThing2()
+    {{
+    }}
+    
+    public void DoThing3(string arg)
+    {{
+    }}
+
+    public void DoThing4(string[] args)
+    {{
+    }}
+}}
+";
+
+    public ScriptMethodsGeneratorTest(ITestOutputHelper testOutputHelper)
+    {
+        this.testOutputHelper = testOutputHelper;
+        GeneratorTestUtil.ForceAssembliesToBeLoadedFoo();
+    }
+
+    [Fact]
+    public void GeneratesMembers()
+    {
+        SyntaxTree syntaxIdComponent = CSharpSyntaxTree.ParseText(MyNodeSource);
+
+        (Compilation? outputCompilation, var diagnostics) =
+            GeneratorTestUtil.RunGeneratorCompilation(new ScriptMethodsGenerator(), syntaxIdComponent);
+        diagnostics.Should().BeEmpty();
+
+        string? output = outputCompilation.SyntaxTrees
+            .Single(tree => tree.FilePath.EndsWith("Test.Node.MyNode_ScriptMethods.generated.cs"))
+            ?.ToString().ReplaceLineEndings();
+
+        output.Should()
+            .Be(
+                @"// Generated code via GodotHat.SourceGenerators.ScriptMethodsGenerator
+namespace Test.Node;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Godot.NativeInterop;
+using Godot;
+
+#nullable enable
+
+file static class MethodInfos {
+    private static readonly global::Godot.Bridge.MethodInfo _ExitTree = new(
+        name: MyNode.MethodName._ExitTree,
+        returnVal: new(
+            type: global::Godot.Variant.Type.Nil,
+            name: new global::Godot.StringName(),
+            hint: global::Godot.PropertyHint.None,
+            hintString: """",
+            usage: global::Godot.PropertyUsageFlags.Storage | global::Godot.PropertyUsageFlags.Editor,
+            exported: false),
+        flags: global::Godot.MethodFlags.Normal,
+        arguments: new() {},
+        defaultArguments: null
+    );
+
+    private static readonly global::Godot.Bridge.MethodInfo _Ready = new(
+        name: MyNode.MethodName._Ready,
+        returnVal: new(
+            type: global::Godot.Variant.Type.Nil,
+            name: new global::Godot.StringName(),
+            hint: global::Godot.PropertyHint.None,
+            hintString: """",
+            usage: global::Godot.PropertyUsageFlags.Storage | global::Godot.PropertyUsageFlags.Editor,
+            exported: false),
+        flags: global::Godot.MethodFlags.Normal,
+        arguments: new() {},
+        defaultArguments: null
+    );
+
+    private static readonly global::Godot.Bridge.MethodInfo DoThing2 = new(
+        name: MyNode.MethodName.DoThing2,
+        returnVal: new(
+            type: global::Godot.Variant.Type.Nil,
+            name: new global::Godot.StringName(),
+            hint: global::Godot.PropertyHint.None,
+            hintString: """",
+            usage: global::Godot.PropertyUsageFlags.Storage | global::Godot.PropertyUsageFlags.Editor,
+            exported: false),
+        flags: global::Godot.MethodFlags.Normal,
+        arguments: new() {},
+        defaultArguments: null
+    );
+
+    private static readonly global::Godot.Bridge.MethodInfo DoThing3 = new(
+        name: MyNode.MethodName.DoThing3,
+        returnVal: new(
+            type: global::Godot.Variant.Type.Nil,
+            name: new global::Godot.StringName(),
+            hint: global::Godot.PropertyHint.None,
+            hintString: """",
+            usage: global::Godot.PropertyUsageFlags.Storage | global::Godot.PropertyUsageFlags.Editor,
+            exported: false),
+        flags: global::Godot.MethodFlags.Normal,
+        arguments: new() {
+                new (
+                    type: global::Godot.Variant.Type.String,
+                    name: new global::Godot.StringName(""arg""),
+                    hint: global::Godot.PropertyHint.None,
+                    hintString: """",
+                    usage: global::Godot.PropertyUsageFlags.Storage | global::Godot.PropertyUsageFlags.Editor,
+                    exported: false),
+        },
+        defaultArguments: null
+    );
+
+    private static readonly global::Godot.Bridge.MethodInfo DoThing4 = new(
+        name: MyNode.MethodName.DoThing4,
+        returnVal: new(
+            type: global::Godot.Variant.Type.Nil,
+            name: new global::Godot.StringName(),
+            hint: global::Godot.PropertyHint.None,
+            hintString: """",
+            usage: global::Godot.PropertyUsageFlags.Storage | global::Godot.PropertyUsageFlags.Editor,
+            exported: false),
+        flags: global::Godot.MethodFlags.Normal,
+        arguments: new() {
+                new (
+                    type: global::Godot.Variant.Type.PackedStringArray,
+                    name: new global::Godot.StringName(""args""),
+                    hint: global::Godot.PropertyHint.None,
+                    hintString: """",
+                    usage: global::Godot.PropertyUsageFlags.Storage | global::Godot.PropertyUsageFlags.Editor,
+                    exported: false),
+        },
+        defaultArguments: null
+    );
+
+
+    public static readonly global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo> GodotMethodList = new() {
+        MethodInfos._ExitTree,
+        MethodInfos._Ready,
+        MethodInfos.DoThing2,
+        MethodInfos.DoThing3,
+        MethodInfos.DoThing4,
+};
+}
+
+public partial class MyNode
+{
+    #pragma warning disable CS0109 // Disable warning about redundant 'new' keyword
+    public new class MethodName : global::Godot.Node.MethodName
+    {
+        public new static readonly global::Godot.StringName _ExitTree = ""_ExitTree"";
+        public new static readonly global::Godot.StringName _Ready = ""_Ready"";
+        public new static readonly global::Godot.StringName DoThing2 = ""DoThing2"";
+        public new static readonly global::Godot.StringName DoThing3 = ""DoThing3"";
+        public new static readonly global::Godot.StringName DoThing4 = ""DoThing4"";
+    }
+
+    internal new static global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo> GetGodotMethodList()
+    {
+        return MethodInfos.GodotMethodList;
+    }
+    #pragma warning restore CS0109
+
+    protected override bool InvokeGodotClassMethod(in godot_string_name method, NativeVariantPtrArgs args, out godot_variant ret)
+    {
+        if (method == MethodName._ExitTree && args.Count == 0)
+        {
+            _ExitTree();
+            ret = default;
+            return true;
+        }
+        if (method == MethodName._Ready && args.Count == 0)
+        {
+            _Ready();
+            ret = default;
+            return true;
+        }
+        if (method == MethodName.DoThing2 && args.Count == 0)
+        {
+            DoThing2();
+            ret = default;
+            return true;
+        }
+        if (method == MethodName.DoThing3 && args.Count == 1)
+        {
+            DoThing3(
+                // arg
+                global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant.Type.String>(args[0]));
+            ret = default;
+            return true;
+        }
+        if (method == MethodName.DoThing4 && args.Count == 1)
+        {
+            DoThing4(
+                // args
+                global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant.Type.PackedStringArray>(args[0]));
+            ret = default;
+            return true;
+        }
+
+        return base.InvokeGodotClassMethod(method, args, out ret);
+    }
+
+    protected override bool HasGodotClassMethod(in godot_string_name method)
+    {
+        if (method == MethodName._ExitTree) return true;
+        if (method == MethodName._Ready) return true;
+        if (method == MethodName.DoThing2) return true;
+        if (method == MethodName.DoThing3) return true;
+        if (method == MethodName.DoThing4) return true;
+
+        return base.HasGodotClassMethod(method);
+    }
+}
+".ReplaceLineEndings());
+    }
+
+}

--- a/GodotHat.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/GodotHat.SourceGenerators/ScriptMethodsGenerator.cs
@@ -27,6 +27,8 @@ public class ScriptMethodsGenerator : IIncrementalGenerator
         INamedTypeSymbol typeGodotObjectClass = GeneratorUtil.GetRequiredType(context.SemanticModel, "Godot.GodotObject");
         INamedTypeSymbol typeAutoDisposeAttribute =
             GeneratorUtil.GetRequiredType(context.SemanticModel, "GodotHat.AutoDisposeAttribute");
+        INamedTypeSymbol typeGodotIgnoreAttribute =
+            GeneratorUtil.GetRequiredType(context.SemanticModel, "GodotHat.GodotIgnoreAttribute");
         INamedTypeSymbol typeOnEnterTreeAttribute =
             GeneratorUtil.GetRequiredType(context.SemanticModel, "GodotHat.OnEnterTreeAttribute");
         INamedTypeSymbol typeOnExitTreeAttribute =
@@ -63,6 +65,7 @@ public class ScriptMethodsGenerator : IIncrementalGenerator
             .Where(s => s is { Kind: SymbolKind.Method, IsImplicitlyDeclared: false, IsStatic: false })
             .Cast<IMethodSymbol>()
             .Where(m => m.MethodKind == MethodKind.Ordinary && m.RefKind == RefKind.None)
+            .Where(m => !m.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, typeGodotIgnoreAttribute)))
             .Select(
                 m =>
                 {

--- a/GodotHat.SourceGenerators/ScriptMethodsGenerator.cs
+++ b/GodotHat.SourceGenerators/ScriptMethodsGenerator.cs
@@ -256,7 +256,7 @@ public class ScriptMethodsGenerator : IIncrementalGenerator
                     (arg, index) =>
                         $@"
                 // {arg.Name}
-                global::Godot.NativeInterop.VariantUtils.ConvertTo<{arg.Type.QualifiedName}>(args[{index}])"));
+                global::Godot.NativeInterop.VariantUtils.ConvertTo<global::Godot.Variant.Type.{arg.Type.VariantType}>(args[{index}])"));
 
         return $@"        if (method == MethodName.{method.Name} && args.Count == {method.Arguments?.Count ?? 0})
         {{
@@ -303,9 +303,8 @@ public class ScriptMethodsGenerator : IIncrementalGenerator
         string methodInfoConstants =
             string.Concat(orderedMethods.Select(m => GodotMethodToBridgeMethodInfo(classSymbol, m.method, m.idx)));
 
-        string methodInfoListAdds = string.Join(
-            lf.ToString(),
-            orderedMethods.Select(m => $"        MethodInfos.{m.method.Name}{m.idx},"));
+        string methodInfoListAdds = string.Concat(
+            orderedMethods.Select(m => $"        MethodInfos.{m.method.Name}{m.idx},{lf}"));
 
         string methodInvokes = string.Concat(
             orderedMethods
@@ -328,8 +327,7 @@ using Godot;
 file static class MethodInfos {{
 {methodInfoConstants}
     public static readonly global::System.Collections.Generic.List<global::Godot.Bridge.MethodInfo> GodotMethodList = new() {{
-{methodInfoListAdds}
-    }};
+{methodInfoListAdds}}};
 }}
 
 {classSyntaxNode.Modifiers} class {classSymbol.Name}


### PR DESCRIPTION
- Fix ScriptMethods arg conversion to variants
- Add GodotIgnore attribute to hide methods from godot ScriptMethods as a fallback (tbh I am leaning towards this being default, and requiring opt-in otherwise)
